### PR TITLE
Remove response_data tuple wrapper

### DIFF
--- a/django_google_structured_logger/middlewares.py
+++ b/django_google_structured_logger/middlewares.py
@@ -113,9 +113,7 @@ class LogRequestAndResponseMiddleware:
                 content_type = self._empty_value_none(
                     getattr(request, "content_type", None)
                 )
-                response_data = (
-                    self._get_request_body(content_type, response_content),
-                )
+                response_data = self._get_request_body(content_type, response_content)
             response_status_code = getattr(response, "status_code", 0)
             response_headers = self._exclude_keys(getattr(response, "headers", None))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,15 @@
 [project]
 name = "django-google-structured-logger"
-version = "2.8.10"
+version = "2.8.11"
 description = "Plugin for django to support  Google Structured Logger"
 authors = [{ name = "Farruh Sheripov", email = "sheripov.farruh@gmail.com" }]
 requires-python = ">=3.9"
 readme = "README.md"
 dependencies = [
-    "python-json-logger>=2.0.7,<3",
-    "contextvars~=2.4",
-    "django>=3,<6",
-    "setuptools-scm>=7.1.0,<8",
+  "python-json-logger>=2.0.7,<3",
+  "contextvars~=2.4",
+  "django>=3,<6",
+  "setuptools-scm>=7.1.0,<8",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
Howdy;
First, thanks for the very useful package -- it solves a real pain point for us.

I'm not sure if this is intended behavior or not, but all response_data output is being wrapped as a single-element tuple. 

It looks like a trailing comma is causing the tuple instead of treating it as an expression result:
https://github.com/muehlemann-popp/django-google-structured-logger/blob/main/django_google_structured_logger/middlewares.py#L117

```py
response_data = (
    self._get_request_body(content_type, response_content),
)
```

Changing it to:
```py
response_data = (
    self._get_request_body(content_type, response_content)
)
```
removes the tuple and array wrapper when stringified as JSON

This PR removes the trailing comma and prevents wrapping all response_data as a single element array.

Thanks for taking a look!